### PR TITLE
Replace top-level await with sync WASM loading to support CJS / NestJS environments

### DIFF
--- a/ts/index.ts
+++ b/ts/index.ts
@@ -11,7 +11,7 @@ function base64ToUint8Array(base64: string): Uint8Array {
   return bytes;
 }
 
-const bytes = base64ToUint8Array(await base64Wasm());
+const bytes = base64ToUint8Array(base64Wasm());
 
 initSync({ module: bytes });
 

--- a/ts/macro.ts
+++ b/ts/macro.ts
@@ -1,5 +1,7 @@
-export const base64Wasm = async () => {
-  const bytes = await Bun.file("./pkg/whatsapp_rust_bridge_bg.wasm").bytes();
+import {readFileSync} from "fs";
+
+export const base64Wasm = () => {
+  const bytes = readFileSync("./pkg/whatsapp_rust_bridge_bg.wasm")
 
   const base64 = bytes.toBase64();
 


### PR DESCRIPTION
`whatsapp-rust-bridge` uses **top-level `await`** when loading WASM:

```js
const bytes = base64ToUint8Array(await base64Wasm());
```

This forces the package to be **ESM-only** and breaks **CommonJS** environments like **NestJS**, causing:

```
Error [ERR_REQUIRE_ASYNC_MODULE]: require() cannot be used on an ESM graph with top-level await
```

**Proposal**
 
Load the WASM **synchronously** instead of using async + top-level await.
**The file is small and loaded only once at module init, so sync IO is acceptable I guess.**


:point_right:  This keeps behavior the same while restoring compatibility with CJS environments.
