### PR TITLE
Implement dual WASM module build process with SIMD and baseline support

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "scripts": {
         "bench": "bun run build && bun run benches/binary.ts && bun run benches/signal.ts && bun run benches/curve.ts && bun run benches/crypto.ts",
         "bench:node": "bun run build && node --expose-gc benches/binary.ts && node --expose-gc benches/signal.ts && node --expose-gc benches/curve.ts && node --expose-gc benches/crypto.ts",
-        "build:wasm": "wasm-pack build --target web --out-dir pkg --no-pack",
+        "build:wasm": "bun scripts/build-dual.ts",
         "build:ts": "bun build ts/index.ts --outfile dist/index.js",
         "postbuild": "tsc -p tsconfig.json --outDir dist && rm -f dist/macro.d.ts",
         "build": "bun run build:wasm && bun run build:ts && bun run postbuild",

--- a/scripts/build-dual.ts
+++ b/scripts/build-dual.ts
@@ -1,0 +1,73 @@
+#!/usr/bin/env bun
+import { rm } from "fs/promises";
+import { spawnSync } from "child_process";
+
+console.log("🔨 Building dual WASM modules (SIMD + baseline)...\n");
+
+// Clean up old builds
+await rm("pkg", { recursive: true, force: true });
+await rm("pkg-nosimd", { recursive: true, force: true });
+
+// 1. Build SIMD version (default with current config)
+console.log("📦 Building SIMD version...");
+const simdBuild = spawnSync(
+    "wasm-pack",
+    ["build", "--target", "web", "--out-dir", "pkg", "--no-pack"],
+    {
+        stdio: "inherit",
+        shell: true,
+    },
+);
+if (simdBuild.status !== 0) {
+    process.exit(1);
+}
+console.log("✅ SIMD build complete\n");
+
+// 2. Build non-SIMD version
+console.log("📦 Building baseline (no-SIMD) version...");
+
+// Temporarily modify config
+const cargoConfig = await Bun.file(".cargo/config.toml").text();
+await Bun.write(
+    ".cargo/config.toml",
+    cargoConfig.replace(
+        'rustflags = ["-C", "target-feature=+simd128"]',
+        "# rustflags = []",
+    ),
+);
+
+// Modify Cargo.toml to disable SIMD in wasm-opt
+const cargoToml = await Bun.file("Cargo.toml").text();
+const modifiedCargoToml = cargoToml.replace(
+    '"--enable-simd",',
+    '# "--enable-simd",',
+);
+await Bun.write("Cargo.toml", modifiedCargoToml);
+
+// Build without SIMD
+const noSimdBuild = spawnSync(
+    "wasm-pack",
+    ["build", "--target", "web", "--out-dir", "pkg-nosimd", "--no-pack"],
+    {
+        stdio: "inherit",
+        shell: true,
+    },
+);
+
+// Restore configs
+await Bun.write(".cargo/config.toml", cargoConfig);
+await Bun.write("Cargo.toml", cargoToml);
+
+if (noSimdBuild.status !== 0) {
+    process.exit(1);
+}
+console.log("✅ Baseline build complete\n");
+
+console.log("📊 Build results:");
+const simdSize = Bun.file("pkg/whatsapp_rust_bridge_bg.wasm").size;
+const noSimdSize = Bun.file("pkg-nosimd/whatsapp_rust_bridge_bg.wasm").size;
+console.log(`  SIMD:     ${(simdSize / 1024).toFixed(1)} KB`);
+console.log(`  Baseline: ${(noSimdSize / 1024).toFixed(1)} KB`);
+console.log(`  Diff:     ${((simdSize - noSimdSize) / 1024).toFixed(1)} KB\n`);
+
+console.log("✨ Dual build complete!");

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -1,6 +1,6 @@
 import { initSync } from "../pkg/whatsapp_rust_bridge.js";
 
-import { base64Wasm } from "./macro.js" with { type: "macro" };
+import { base64Wasm, base64WasmNoSimd } from "./macro.js" with { type: "macro" };
 
 function base64ToUint8Array(base64: string): Uint8Array {
   const binaryString = atob(base64);
@@ -11,7 +11,24 @@ function base64ToUint8Array(base64: string): Uint8Array {
   return bytes;
 }
 
-const bytes = base64ToUint8Array(base64Wasm());
+// Detect WASM SIMD support
+function wasmSupportsSimd(): boolean {
+  try {
+    // Test if SIMD is supported by compiling a minimal SIMD module
+    const simdTest = new Uint8Array([
+      0, 97, 115, 109, 1, 0, 0, 0, 1, 5, 1, 96, 0, 1, 123, 3, 2, 1, 0, 10, 10,
+      1, 8, 0, 65, 0, 253, 15, 253, 98, 11,
+    ]);
+    return WebAssembly.validate(simdTest);
+  } catch {
+    return false;
+  }
+}
+
+// Load appropriate WASM module based on SIMD support
+const hasSimd = wasmSupportsSimd();
+const wasmBase64 = hasSimd ? base64Wasm() : base64WasmNoSimd();
+const bytes = base64ToUint8Array(wasmBase64);
 
 initSync({ module: bytes });
 

--- a/ts/macro.ts
+++ b/ts/macro.ts
@@ -2,8 +2,10 @@ import {readFileSync} from "fs";
 
 export const base64Wasm = () => {
   const bytes = readFileSync("./pkg/whatsapp_rust_bridge_bg.wasm")
+  return bytes.toBase64();
+};
 
-  const base64 = bytes.toBase64();
-
-  return base64;
+export const base64WasmNoSimd = () => {
+  const bytes = readFileSync("./pkg-nosimd/whatsapp_rust_bridge_bg.wasm")
+  return bytes.toBase64();
 };


### PR DESCRIPTION
This pull request introduces dual WASM module builds (SIMD and baseline) and updates the loading logic to dynamically select the appropriate module based on runtime SIMD support. The changes improve compatibility across environments and streamline the build process.

Build system improvements:

* Added a new script `scripts/build-dual.ts` to automate building both SIMD and non-SIMD WASM modules, including config modifications and restoring, and reporting build sizes. (`build:wasm` in `package.json` now uses this script) [[1]](diffhunk://#diff-7ea878eb05524d62daa94fe4787148b16673f5edec1f3b45ff54a50f501afe31R1-R73) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L25-R25)

WASM module loading enhancements:

* Updated `ts/index.ts` to detect WASM SIMD support at runtime and load either the SIMD or baseline WASM module accordingly, improving compatibility.
* Modified `ts/macro.ts` to export both `base64Wasm` and `base64WasmNoSimd`, enabling access to both module variants for dynamic loading.
* Updated imports in `ts/index.ts` to include `base64WasmNoSimd` for dual module support.