### PR TITLE
Migrate to whatsapp-rust 0.5 stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,47 +9,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "aead"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
-dependencies = [
- "crypto-common 0.1.7",
- "generic-array",
-]
-
-[[package]]
 name = "aes"
-version = "0.8.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+checksum = "66bd29a732b644c0431c6140f370d097879203d79b80c94a6747ba0872adaef8"
 dependencies = [
- "cfg-if",
  "cipher",
- "cpufeatures 0.2.17",
-]
-
-[[package]]
-name = "aes-gcm"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
-dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "ghash 0.5.1",
- "subtle",
-]
-
-[[package]]
-name = "aho-corasick"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
-dependencies = [
- "memchr",
+ "cpubits",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -101,9 +68,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -115,12 +82,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-padding"
-version = "0.3.3"
+name = "block-buffer"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
- "generic-array",
+ "hybrid-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -146,15 +122,21 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
- "serde",
+ "rustversion",
 ]
 
 [[package]]
 name = "cbc"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+checksum = "98db6aeaef0eeef2c1e3ce9a27b739218825dae116076352ac3777076aa22225"
 dependencies = [
  "cipher",
 ]
@@ -166,36 +148,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "num-traits",
- "serde",
 ]
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+checksum = "e34d8227fe1ba289043aeb13792056ff80fd6de1a9f49137a5f499de8e8c78ea"
 dependencies = [
- "crypto-common 0.1.7",
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.1",
  "inout",
 ]
 
 [[package]]
 name = "cmov"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0758edba32d61d1fd9f4d69491b47604b91ee2f7e6b33de7e54ca4ebe55dc3"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
+]
 
 [[package]]
 name = "cpubits"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef0c543070d296ea414df2dd7625d1b24866ce206709d8a4a424f28377f5861"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -245,18 +253,18 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.9.2"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+checksum = "17469f8eb9bdbfad10f71f4cfddfd38b01143520c0e717d8796ccb4d44d44e42"
 dependencies = [
  "cipher",
 ]
 
 [[package]]
 name = "ctutils"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1005a6d4446f5120ef475ad3d2af2b30c49c2c9c6904258e3bb30219bebed5e4"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
 ]
@@ -270,7 +278,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -315,9 +323,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -353,22 +372,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "errno"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
-dependencies = [
- "libc",
- "windows-sys",
-]
-
-[[package]]
-name = "fastrand"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,12 +385,6 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
-
-[[package]]
-name = "fixedbitset"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -442,39 +439,18 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "js-sys",
- "libc",
- "r-efi 5.3.0",
- "wasip2",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
- "r-efi 6.0.0",
+ "r-efi",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
-]
-
-[[package]]
-name = "ghash"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
-dependencies = [
- "opaque-debug",
- "polyval 0.6.2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -483,7 +459,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
 dependencies = [
- "polyval 0.7.1",
+ "polyval",
 ]
 
 [[package]]
@@ -497,9 +473,21 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hashify"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd1246c0e5493286aeb2dde35b1f4eb9c4ce00e628641210a5e553fc001a1f26"
+dependencies = [
+ "indexmap",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "heck"
@@ -519,7 +507,16 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -528,14 +525,23 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.8"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8655f91cd07f2b9d0c24137bd650fe69617773435ee5ec83022377777ce65ef1"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
 dependencies = [
  "typenum",
 ]
@@ -585,24 +591,24 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
 
 [[package]]
 name = "inout"
-version = "0.1.4"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
  "block-padding",
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -616,16 +622,18 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -644,15 +652,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "log"
@@ -667,7 +669,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -697,12 +699,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "multimap"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -718,61 +714,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
-name = "petgraph"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
-dependencies = [
- "fixedbitset",
- "hashbrown 0.15.5",
- "indexmap",
-]
-
-[[package]]
-name = "phf"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
-dependencies = [
- "phf_shared",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
-dependencies = [
- "phf_generator",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
-dependencies = [
- "fastrand",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,23 +725,11 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "crc32fast",
  "fdeflate",
  "flate2",
  "miniz_oxide",
-]
-
-[[package]]
-name = "polyval"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "opaque-debug",
- "universal-hash 0.5.1",
 ]
 
 [[package]]
@@ -811,16 +740,7 @@ checksum = "7dfc63250416fea14f5749b90725916a6c903f599d51cb635aa7a52bfd03eede"
 dependencies = [
  "cpubits",
  "cpufeatures 0.3.0",
- "universal-hash 0.6.1",
-]
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
+ "universal-hash",
 ]
 
 [[package]]
@@ -853,23 +773,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-build"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
-dependencies = [
- "heck",
- "itertools",
- "log",
- "multimap",
- "petgraph",
- "prost",
- "prost-types",
- "regex",
- "tempfile",
-]
-
-[[package]]
 name = "prost-derive"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -883,19 +786,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-types"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
-dependencies = [
- "prost",
-]
-
-[[package]]
 name = "pxfm"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "quick-error"
@@ -914,34 +808,19 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "rand_chacha",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
+ "chacha20",
+ "getrandom",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -952,41 +831,9 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
-]
-
-[[package]]
-name = "regex"
-version = "1.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rustc_version"
@@ -998,29 +845,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustix"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
-dependencies = [
- "bitflags 2.11.0",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys",
-]
-
-[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "semver"
-version = "1.0.27"
+name = "ryu"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1108,13 +948,13 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1125,26 +965,43 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
-
-[[package]]
-name = "siphasher"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "subtle"
@@ -1262,16 +1119,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.27.0"
+name = "synstructure"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
- "fastrand",
- "getrandom 0.4.2",
- "once_cell",
- "rustix",
- "windows-sys",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1320,9 +1175,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-ident"
@@ -1338,16 +1193,6 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
-dependencies = [
- "crypto-common 0.1.7",
- "subtle",
-]
-
-[[package]]
-name = "universal-hash"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
@@ -1358,11 +1203,11 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -1375,19 +1220,19 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wacore-appstate"
-version = "0.3.0"
-source = "git+https://github.com/jlucaso1/whatsapp-rust.git?branch=main#95397408f84fda502c3bb2c755fda82a07cab055"
+version = "0.5.0"
+source = "git+https://github.com/jlucaso1/whatsapp-rust.git?branch=main#88a0fe074fdc09d73be95cdd23743fba22ef172e"
 dependencies = [
  "anyhow",
  "bytemuck",
  "hex",
- "hkdf",
+ "hkdf 0.13.0",
  "log",
  "prost",
  "serde",
  "serde-big-array",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "thiserror",
  "wacore-binary",
  "wacore-libsignal",
@@ -1396,42 +1241,45 @@ dependencies = [
 
 [[package]]
 name = "wacore-binary"
-version = "0.3.0"
-source = "git+https://github.com/jlucaso1/whatsapp-rust.git?branch=main#95397408f84fda502c3bb2c755fda82a07cab055"
+version = "0.5.0"
+source = "git+https://github.com/jlucaso1/whatsapp-rust.git?branch=main#88a0fe074fdc09d73be95cdd23743fba22ef172e"
 dependencies = [
+ "bytes",
+ "compact_str",
  "flate2",
- "phf",
- "phf_codegen",
+ "hashify",
+ "itoa",
  "serde",
  "serde_json",
+ "stable_deref_trait",
+ "yoke",
 ]
 
 [[package]]
 name = "wacore-libsignal"
-version = "0.3.0"
-source = "git+https://github.com/jlucaso1/whatsapp-rust.git?branch=main#95397408f84fda502c3bb2c755fda82a07cab055"
+version = "0.5.0"
+source = "git+https://github.com/jlucaso1/whatsapp-rust.git?branch=main#88a0fe074fdc09d73be95cdd23743fba22ef172e"
 dependencies = [
  "aes",
- "aes-gcm",
  "arrayref",
  "async-trait",
+ "bytes",
  "cbc",
  "chrono",
  "ctr",
  "curve25519-dalek",
  "derive_more",
  "displaydoc",
- "ghash 0.6.0",
+ "ghash",
  "hex",
- "hkdf",
- "hmac",
- "itertools",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
  "log",
  "prost",
  "rand",
  "serde",
  "sha1",
- "sha2",
+ "sha2 0.11.0",
  "subtle",
  "thiserror",
  "uuid",
@@ -1441,17 +1289,16 @@ dependencies = [
 
 [[package]]
 name = "wacore-noise"
-version = "0.3.0"
-source = "git+https://github.com/jlucaso1/whatsapp-rust.git?branch=main#95397408f84fda502c3bb2c755fda82a07cab055"
+version = "0.5.0"
+source = "git+https://github.com/jlucaso1/whatsapp-rust.git?branch=main#88a0fe074fdc09d73be95cdd23743fba22ef172e"
 dependencies = [
- "aes-gcm",
  "anyhow",
  "bytes",
- "hkdf",
+ "hkdf 0.13.0",
  "log",
  "prost",
  "rand",
- "sha2",
+ "sha2 0.11.0",
  "thiserror",
  "wacore-binary",
  "wacore-libsignal",
@@ -1460,21 +1307,20 @@ dependencies = [
 
 [[package]]
 name = "waproto"
-version = "0.3.0"
-source = "git+https://github.com/jlucaso1/whatsapp-rust.git?branch=main#95397408f84fda502c3bb2c755fda82a07cab055"
+version = "0.5.0"
+source = "git+https://github.com/jlucaso1/whatsapp-rust.git?branch=main#88a0fe074fdc09d73be95cdd23743fba22ef172e"
 dependencies = [
  "prost",
- "prost-build",
  "serde",
 ]
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -1483,14 +1329,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1501,23 +1347,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1525,9 +1367,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1538,9 +1380,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -1573,7 +1415,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -1581,9 +1423,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1596,9 +1438,10 @@ dependencies = [
  "async-trait",
  "base64",
  "curve25519-dalek",
- "getrandom 0.3.4",
- "hkdf",
- "hmac",
+ "getrandom",
+ "hashify",
+ "hkdf 0.12.4",
+ "hmac 0.12.1",
  "image",
  "img-parts",
  "js-sys",
@@ -1610,7 +1453,7 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_bytes",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "simd-adler32",
  "symphonia",
  "tsify-next",
@@ -1626,21 +1469,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-link"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-sys"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1648,6 +1476,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -1698,7 +1532,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",
@@ -1741,23 +1575,47 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerocopy"
-version = "0.8.42"
+name = "yoke"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
- "zerocopy-derive",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
 ]
 
 [[package]]
-name = "zerocopy-derive"
-version = "0.8.42"
+name = "yoke-derive"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -1800,9 +1658,9 @@ checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
 
 [[package]]
 name = "zune-jpeg"
-version = "0.5.13"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec5f41c76397b7da451efd19915684f727d7e1d516384ca6bd0ec43ec94de23c"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,8 @@ curve25519-dalek = { version = "4.1.3", default-features = false, features = [
   "digest",
   "precomputed-tables",
 ] }
-getrandom = { version = "0.3.4", features = ["wasm_js"] }
+getrandom = { version = "0.4", features = ["wasm_js"] }
+hashify = { version = "0.2.9", default-features = false, features = ["force-32bit"] }
 hkdf = "0.12"
 hmac = "0.12"
 image = { version = "0.25.5", default-features = false, features = [
@@ -60,9 +61,10 @@ js-sys = "0.3"
 log = "0.4"
 md-5 = "0.10"
 prost = { version = "0.14.1", default-features = false }
-rand = { version = "0.9.2", default-features = false, features = [
+rand = { version = "0.10", default-features = false, features = [
   "std",
   "std_rng",
+  "sys_rng",
 ] }
 serde = { version = "1.0.228", default-features = false, features = [
   "derive",
@@ -85,7 +87,7 @@ tsify-next = { version = "0.5", default-features = false, features = ["js"] }
 uuid = { version = "1.18.1", default-features = false, features = ["v4", "js"] }
 
 wacore-appstate = { git = "https://github.com/jlucaso1/whatsapp-rust.git", branch = "main", package = "wacore-appstate" }
-wacore-binary = { git = "https://github.com/jlucaso1/whatsapp-rust.git", branch = "main", features = [
+wacore-binary = { git = "https://github.com/jlucaso1/whatsapp-rust.git", branch = "main", default-features = false, features = [
   "serde",
 ] }
 wacore-libsignal = { git = "https://github.com/jlucaso1/whatsapp-rust.git", branch = "main", package = "wacore-libsignal" }

--- a/benches/signal.ts
+++ b/benches/signal.ts
@@ -95,114 +95,104 @@ class LibsignalStore implements SignalStorage {
 }
 
 // ============================================================================
-// Setup for Rust WASM benchmarks
+// Setup helpers — each bench group gets its own fresh session pair so the
+// ratchet doesn't drift past libsignal's MAX_FORWARD_JUMPS (25_000) when one
+// bench advances the chain solo (e.g. an Encrypt-only bench) before Decrypt
+// has a chance to catch up.
 // ============================================================================
-const aliceStorage = new FakeStorage();
-const bobStorage = new FakeStorage();
 
-const wasmBobAddress = new ProtocolAddress("bob", 1);
-const wasmAliceAddress = new ProtocolAddress("alice", 1);
-
-// Trust each other's identities
-aliceStorage.trustIdentity("bob", bobStorage.ourIdentityKeyPair.pubKey);
-bobStorage.trustIdentity("alice", aliceStorage.ourIdentityKeyPair.pubKey);
-
-// Generate Bob's pre-keys for WASM
-const bobSignedPreKeyId = 1;
-const bobSignedPreKey = generateSignedPreKey(
-  bobStorage.ourIdentityKeyPair,
-  bobSignedPreKeyId,
-);
-const bobOneTimePreKey = generatePreKey(100);
-
-bobStorage.storeSignedPreKey(bobSignedPreKey.keyId, bobSignedPreKey);
-bobStorage.storePreKey(bobOneTimePreKey.keyId, bobOneTimePreKey.keyPair);
-
-const bobBundle = {
-  registrationId: bobStorage.ourRegistrationId,
-  identityKey: bobStorage.ourIdentityKeyPair.pubKey,
-  signedPreKey: {
-    keyId: bobSignedPreKey.keyId,
-    publicKey: bobSignedPreKey.keyPair.pubKey,
-    signature: bobSignedPreKey.signature,
-  },
-  preKey: {
-    keyId: bobOneTimePreKey.keyId,
-    publicKey: bobOneTimePreKey.keyPair.pubKey,
-  },
+type WasmPair = {
+  alice: SessionCipher;
+  bob: SessionCipher;
 };
 
-// Alice processes Bob's bundle and establishes session
-const aliceSessionBuilder = new SessionBuilder(aliceStorage, wasmBobAddress);
-await aliceSessionBuilder.processPreKeyBundle(bobBundle);
+async function makeWasmPair(): Promise<WasmPair> {
+  const aliceStorage = new FakeStorage();
+  const bobStorage = new FakeStorage();
+  const bobAddr = new ProtocolAddress("bob", 1);
+  const aliceAddr = new ProtocolAddress("alice", 1);
 
-const aliceCipher = new SessionCipher(aliceStorage, wasmBobAddress);
-const bobCipher = new SessionCipher(bobStorage, wasmAliceAddress);
+  aliceStorage.trustIdentity("bob", bobStorage.ourIdentityKeyPair.pubKey);
+  bobStorage.trustIdentity("alice", aliceStorage.ourIdentityKeyPair.pubKey);
 
-// ============================================================================
-// Setup for libsignal-node benchmarks
-// ============================================================================
-const aliceLibsignalStorage = new LibsignalStore();
-const bobLibsignalStorage = new LibsignalStore();
+  const sk = generateSignedPreKey(bobStorage.ourIdentityKeyPair, 1);
+  const pk = generatePreKey(100);
+  bobStorage.storeSignedPreKey(sk.keyId, sk);
+  bobStorage.storePreKey(pk.keyId, pk.keyPair);
 
-const libsignalBobAddress = new libsignalNode.ProtocolAddress("bob", 1);
-const libsignalAliceAddress = new libsignalNode.ProtocolAddress("alice", 1);
+  await new SessionBuilder(aliceStorage, bobAddr).processPreKeyBundle({
+    registrationId: bobStorage.ourRegistrationId,
+    identityKey: bobStorage.ourIdentityKeyPair.pubKey,
+    signedPreKey: {
+      keyId: sk.keyId,
+      publicKey: sk.keyPair.pubKey,
+      signature: sk.signature,
+    },
+    preKey: { keyId: pk.keyId, publicKey: pk.keyPair.pubKey },
+  });
 
-// Trust each other's identities
-aliceLibsignalStorage.trustIdentity(
-  "bob",
-  Buffer.from(bobLibsignalStorage.ourIdentityKeyPair.pubKey),
-);
-bobLibsignalStorage.trustIdentity(
-  "alice",
-  Buffer.from(aliceLibsignalStorage.ourIdentityKeyPair.pubKey),
-);
+  const alice = new SessionCipher(aliceStorage, bobAddr);
+  const bob = new SessionCipher(bobStorage, aliceAddr);
 
-// Generate Bob's pre-keys for libsignal-node
-const bobLibSignedPreKey = libsignalKeyHelper.generateSignedPreKey(
-  bobLibsignalStorage.ourIdentityKeyPair,
-  bobSignedPreKeyId,
-);
-const bobLibOneTimePreKey = libsignalKeyHelper.generatePreKey(100);
+  // PreKey handshake + reply so both sides have established sessions
+  const first = await alice.encrypt(Buffer.from("hi"));
+  await bob.decryptPreKeyWhisperMessage(first.body);
+  const reply = await bob.encrypt(Buffer.from("ack"));
+  await alice.decryptWhisperMessage(reply.body);
 
-bobLibsignalStorage.storeSignedPreKey(
-  bobLibSignedPreKey.keyId,
-  bobLibSignedPreKey,
-);
-bobLibsignalStorage.storePreKey(
-  bobLibOneTimePreKey.keyId,
-  bobLibOneTimePreKey.keyPair,
-);
+  return { alice, bob };
+}
 
-const bobLibsignalBundle = {
-  registrationId: bobLibsignalStorage.ourRegistrationId,
-  identityKey: bobLibsignalStorage.ourIdentityKeyPair.pubKey,
-  signedPreKey: {
-    keyId: bobLibSignedPreKey.keyId,
-    publicKey: bobLibSignedPreKey.keyPair.pubKey,
-    signature: bobLibSignedPreKey.signature,
-  },
-  preKey: {
-    keyId: bobLibOneTimePreKey.keyId,
-    publicKey: bobLibOneTimePreKey.keyPair.pubKey,
-  },
+type LibPair = {
+  alice: InstanceType<typeof libsignalNode.SessionCipher>;
+  bob: InstanceType<typeof libsignalNode.SessionCipher>;
 };
 
-// Alice processes Bob's bundle and establishes session
-const aliceLibsignalBuilder = new libsignalNode.SessionBuilder(
-  aliceLibsignalStorage,
-  libsignalBobAddress,
-);
-await aliceLibsignalBuilder.initOutgoing(bobLibsignalBundle);
+async function makeLibPair(): Promise<LibPair> {
+  const aliceStorage = new LibsignalStore();
+  const bobStorage = new LibsignalStore();
+  const bobAddr = new libsignalNode.ProtocolAddress("bob", 1);
+  const aliceAddr = new libsignalNode.ProtocolAddress("alice", 1);
 
-const aliceLibsignalCipher = new libsignalNode.SessionCipher(
-  aliceLibsignalStorage,
-  libsignalBobAddress,
-);
-const bobLibsignalCipher = new libsignalNode.SessionCipher(
-  bobLibsignalStorage,
-  libsignalAliceAddress,
-);
+  aliceStorage.trustIdentity(
+    "bob",
+    Buffer.from(bobStorage.ourIdentityKeyPair.pubKey),
+  );
+  bobStorage.trustIdentity(
+    "alice",
+    Buffer.from(aliceStorage.ourIdentityKeyPair.pubKey),
+  );
+
+  const sk = libsignalKeyHelper.generateSignedPreKey(
+    bobStorage.ourIdentityKeyPair,
+    1,
+  );
+  const pk = libsignalKeyHelper.generatePreKey(100);
+  bobStorage.storeSignedPreKey(sk.keyId, sk);
+  bobStorage.storePreKey(pk.keyId, pk.keyPair);
+
+  const builder = new libsignalNode.SessionBuilder(aliceStorage, bobAddr);
+  await builder.initOutgoing({
+    registrationId: bobStorage.ourRegistrationId,
+    identityKey: bobStorage.ourIdentityKeyPair.pubKey,
+    signedPreKey: {
+      keyId: sk.keyId,
+      publicKey: sk.keyPair.pubKey,
+      signature: sk.signature,
+    },
+    preKey: { keyId: pk.keyId, publicKey: pk.keyPair.pubKey },
+  });
+
+  const alice = new libsignalNode.SessionCipher(aliceStorage, bobAddr);
+  const bob = new libsignalNode.SessionCipher(bobStorage, aliceAddr);
+
+  const first = await alice.encrypt(Buffer.from("hi"));
+  await bob.decryptPreKeyWhisperMessage(first.body as unknown as Uint8Array);
+  const reply = await bob.encrypt(Buffer.from("ack"));
+  await alice.decryptWhisperMessage(reply.body as unknown as Uint8Array);
+
+  return { alice, bob };
+}
 
 // ============================================================================
 // Test Messages
@@ -215,80 +205,79 @@ const typicalMessage = Buffer.from(
   ),
 );
 
-// ============================================================================
-// Establish bidirectional sessions (required for decrypt benchmarks)
-// ============================================================================
-
-// WASM: Alice sends first message (PreKeyWhisperMessage)
-const wasmFirstEncrypted = await aliceCipher.encrypt(typicalMessage);
-// Bob decrypts first message - this establishes Bob's session with Alice
-await bobCipher.decryptPreKeyWhisperMessage(wasmFirstEncrypted.body);
-// Bob replies to Alice - this completes the ratchet setup
-const wasmBobReply = await bobCipher.encrypt(typicalMessage);
-// Alice decrypts Bob's reply - now both sides have established sessions
-await aliceCipher.decryptWhisperMessage(wasmBobReply.body);
-
-// libsignal-node: Same pattern
-const libsignalFirstEncrypted =
-  await aliceLibsignalCipher.encrypt(typicalMessage);
-await bobLibsignalCipher.decryptPreKeyWhisperMessage(
-  libsignalFirstEncrypted.body as unknown as Uint8Array,
-);
-const libsignalBobReply = await bobLibsignalCipher.encrypt(typicalMessage);
-await aliceLibsignalCipher.decryptWhisperMessage(
-  libsignalBobReply.body as unknown as Uint8Array,
-);
-
-// Now both Alice and Bob have fully established sessions in both libraries
+// Each bench group below gets its own fresh session pair. This prevents one
+// bench (e.g. Encrypt) from advancing the ratchet past the
+// MAX_FORWARD_JUMPS=25_000 threshold and breaking subsequent Decrypt benches.
 
 // ============================================================================
-// Benchmarks
+// Encrypt benchmarks
 // ============================================================================
+const encWasm = await makeWasmPair();
+const encLib = await makeLibPair();
 
 boxplot(() => {
   summary(() => {
     bench("Encrypt typical message (Rust WASM)", async () => {
-      const result = await aliceCipher.encrypt(typicalMessage);
+      const result = await encWasm.alice.encrypt(typicalMessage);
       do_not_optimize(result);
     }).gc("inner");
 
     bench("Encrypt typical message (libsignal-node)", async () => {
-      const result = await aliceLibsignalCipher.encrypt(typicalMessage);
+      const result = await encLib.alice.encrypt(typicalMessage);
       do_not_optimize(result);
     }).gc("inner");
   });
+});
 
+// ============================================================================
+// Decrypt benchmarks (fresh sessions — independent of Encrypt above)
+// ============================================================================
+const decWasm = await makeWasmPair();
+const decLib = await makeLibPair();
+
+// Use mitata's generator form so the encrypt setup runs outside the timed
+// section (the [0] callback is invoked per-iteration before t0). The bench
+// body only measures Bob's decrypt. Each iteration consumes a fresh
+// ciphertext because both ratchets advance on every encrypt/decrypt.
+boxplot(() => {
   summary(() => {
-    // Decrypt benchmarks - Alice encrypts, Bob decrypts
-    // Both sides now have established sessions, so these are WhisperMessages (type 1)
-    bench("Decrypt WhisperMessage (Rust WASM)", async () => {
-      // Alice encrypts a fresh message to Bob
-      const encrypted = await aliceCipher.encrypt(typicalMessage);
-      // Bob decrypts it - this advances the ratchet
-      const result = await bobCipher.decryptWhisperMessage(encrypted.body);
-      do_not_optimize(result);
+    bench("Decrypt WhisperMessage (Rust WASM)", function* () {
+      yield {
+        [0]: async () => await decWasm.alice.encrypt(typicalMessage),
+        bench: async (encrypted: { body: Uint8Array }) => {
+          const result = await decWasm.bob.decryptWhisperMessage(encrypted.body);
+          do_not_optimize(result);
+        },
+      };
     }).gc("inner");
 
-    bench("Decrypt WhisperMessage (libsignal-node)", async () => {
-      // Alice encrypts a fresh message to Bob
-      const encrypted = await aliceLibsignalCipher.encrypt(typicalMessage);
-      // Bob decrypts it - this advances the ratchet
-      const result = await bobLibsignalCipher.decryptWhisperMessage(
-        encrypted.body as unknown as Uint8Array,
-      );
-      do_not_optimize(result);
+    bench("Decrypt WhisperMessage (libsignal-node)", function* () {
+      yield {
+        [0]: async () => await decLib.alice.encrypt(typicalMessage),
+        bench: async (encrypted: { body: unknown }) => {
+          const result = await decLib.bob.decryptWhisperMessage(
+            encrypted.body as unknown as Uint8Array,
+          );
+          do_not_optimize(result);
+        },
+      };
     }).gc("inner");
   });
+});
 
+// ============================================================================
+// Full round-trip benchmarks (fresh sessions)
+// ============================================================================
+const rtWasm = await makeWasmPair();
+const rtLib = await makeLibPair();
+
+boxplot(() => {
   summary(() => {
-    // Full round-trip: Alice -> Bob -> Alice
     bench("Full round-trip encrypt+decrypt (Rust WASM)", async () => {
-      // Alice sends to Bob
-      const toBob = await aliceCipher.encrypt(typicalMessage);
-      const decryptedByBob = await bobCipher.decryptWhisperMessage(toBob.body);
-      // Bob replies to Alice
-      const toAlice = await bobCipher.encrypt(typicalMessage);
-      const decryptedByAlice = await aliceCipher.decryptWhisperMessage(
+      const toBob = await rtWasm.alice.encrypt(typicalMessage);
+      const decryptedByBob = await rtWasm.bob.decryptWhisperMessage(toBob.body);
+      const toAlice = await rtWasm.bob.encrypt(typicalMessage);
+      const decryptedByAlice = await rtWasm.alice.decryptWhisperMessage(
         toAlice.body,
       );
       do_not_optimize(decryptedByBob);
@@ -296,14 +285,12 @@ boxplot(() => {
     }).gc("inner");
 
     bench("Full round-trip encrypt+decrypt (libsignal-node)", async () => {
-      // Alice sends to Bob
-      const toBob = await aliceLibsignalCipher.encrypt(typicalMessage);
-      const decryptedByBob = await bobLibsignalCipher.decryptWhisperMessage(
+      const toBob = await rtLib.alice.encrypt(typicalMessage);
+      const decryptedByBob = await rtLib.bob.decryptWhisperMessage(
         toBob.body as unknown as Uint8Array,
       );
-      // Bob replies to Alice
-      const toAlice = await bobLibsignalCipher.encrypt(typicalMessage);
-      const decryptedByAlice = await aliceLibsignalCipher.decryptWhisperMessage(
+      const toAlice = await rtLib.bob.encrypt(typicalMessage);
+      const decryptedByAlice = await rtLib.alice.decryptWhisperMessage(
         toAlice.body as unknown as Uint8Array,
       );
       do_not_optimize(decryptedByBob);

--- a/src/binary.rs
+++ b/src/binary.rs
@@ -109,9 +109,7 @@ export interface BinaryNode {
 pub struct InternalBinaryNode {
     _owned_data: Rc<[u8]>,
     node_ref: NodeRef<'static>,
-    #[wasm_bindgen(skip)]
     cached_attrs: UnsafeCell<Option<Attrs>>,
-    #[wasm_bindgen(skip)]
     cached_content: UnsafeCell<Option<Content>>,
 }
 

--- a/src/binary.rs
+++ b/src/binary.rs
@@ -5,7 +5,7 @@ use std::mem;
 use std::rc::Rc;
 use wacore_binary::{
     marshal::{marshal_ref, unmarshal_ref},
-    node::{NodeContentRef, NodeRef, ValueRef},
+    node::{AttrsRef, NodeContentRef, NodeRef, NodeStr, ValueRef},
     util::unpack,
 };
 use wasm_bindgen::prelude::*;
@@ -64,7 +64,10 @@ pub(crate) fn js_to_node_ref(val: &EncodingNode) -> Result<NodeRef<'static>, JsV
             continue;
         };
 
-        attrs.push((Cow::Owned(key), ValueRef::String(Cow::Owned(value_str))));
+        attrs.push((
+            NodeStr::Owned(key.into()),
+            ValueRef::String(NodeStr::Owned(value_str.into())),
+        ));
     }
 
     let content_js = val.content();
@@ -72,7 +75,9 @@ pub(crate) fn js_to_node_ref(val: &EncodingNode) -> Result<NodeRef<'static>, JsV
     let content = if content_js.is_undefined() {
         Ok(None)
     } else if let Some(string_value) = content_js.as_string() {
-        Ok(Some(NodeContentRef::String(Cow::Owned(string_value))))
+        Ok(Some(NodeContentRef::String(NodeStr::Owned(
+            string_value.into(),
+        ))))
     } else if content_js.is_instance_of::<Uint8Array>() {
         let byte_array: Uint8Array = content_js.unchecked_into();
         let len = byte_array.length() as usize;
@@ -88,12 +93,16 @@ pub(crate) fn js_to_node_ref(val: &EncodingNode) -> Result<NodeRef<'static>, JsV
                 js_to_node_ref(&child_node)
             })
             .collect::<Result<Vec<NodeRef<'static>>, _>>()?;
-        Ok(Some(NodeContentRef::Nodes(Box::new(nodes))))
+        Ok(Some(NodeContentRef::Nodes(nodes.into_boxed_slice())))
     } else {
         Err(JsValue::from_str("Invalid content type"))
     };
 
-    Ok(NodeRef::new(Cow::Owned(val.tag()), attrs, content?))
+    Ok(NodeRef::new(
+        NodeStr::Owned(val.tag().into()),
+        AttrsRef::from_vec(attrs),
+        content?,
+    ))
 }
 
 #[wasm_bindgen(typescript_custom_section)]
@@ -120,13 +129,10 @@ impl InternalBinaryNode {
     }
 
     #[inline]
-    fn convert_attrs(attrs: &[(Cow<'_, str>, ValueRef<'_>)]) -> Attrs {
+    fn convert_attrs(attrs: &AttrsRef<'_>) -> Attrs {
         let obj = Object::new();
-        for (k, v) in attrs.iter() {
-            let js_value = match v.as_str() {
-                Some(s) => JsValue::from_str(s),
-                None => JsValue::from_str(&v.to_string()),
-            };
+        for (k, v) in attrs.as_slice().iter() {
+            let js_value = JsValue::from_str(&v.as_str());
             let _ = js_sys::Reflect::set(&obj, &JsValue::from_str(k), &js_value);
         }
         obj.unchecked_into()

--- a/src/binary.rs
+++ b/src/binary.rs
@@ -80,10 +80,7 @@ pub(crate) fn js_to_node_ref(val: &EncodingNode) -> Result<NodeRef<'static>, JsV
         ))))
     } else if content_js.is_instance_of::<Uint8Array>() {
         let byte_array: Uint8Array = content_js.unchecked_into();
-        let len = byte_array.length() as usize;
-        let mut bytes = vec![0; len];
-        byte_array.copy_to(&mut bytes);
-        Ok(Some(NodeContentRef::Bytes(Cow::Owned(bytes))))
+        Ok(Some(NodeContentRef::Bytes(Cow::Owned(byte_array.to_vec()))))
     } else if Array::is_array(&content_js) {
         let arr = Array::from(&content_js);
         let nodes = (0..arr.length())
@@ -217,10 +214,7 @@ impl InternalBinaryNode {
 
         let result: Option<Content> = match self.node_ref().content.as_deref() {
             Some(NodeContentRef::Bytes(bytes)) => {
-                let bytes_ref = bytes.as_ref();
-                let u8arr = Uint8Array::new_with_length(bytes_ref.len() as u32);
-                u8arr.copy_from(bytes_ref);
-                Some(u8arr.unchecked_into())
+                Some(Uint8Array::from(bytes.as_ref()).unchecked_into())
             }
             Some(NodeContentRef::String(s)) => Some(JsValue::from_str(s).unchecked_into()),
             Some(NodeContentRef::Nodes(nodes)) => {
@@ -254,10 +248,7 @@ impl InternalBinaryNode {
 pub fn encode_node(node_val: EncodingNode) -> Result<Uint8Array, JsValue> {
     let node_ref = js_to_node_ref(&node_val)?;
     let bytes = marshal_ref(&node_ref).map_err(|e| JsValue::from_str(&e.to_string()))?;
-
-    let result = Uint8Array::new_with_length(bytes.len() as u32);
-    result.copy_from(&bytes);
-    Ok(result)
+    Ok(Uint8Array::from(bytes.as_slice()))
 }
 
 #[wasm_bindgen(js_name = decodeNode)]

--- a/src/curve.rs
+++ b/src/curve.rs
@@ -1,6 +1,6 @@
 use curve25519_dalek::{Scalar, constants::ED25519_BASEPOINT_TABLE};
 use js_sys::Uint8Array;
-use rand::{TryRngCore, rngs::OsRng};
+use rand::rngs::StdRng;
 use serde::{Deserialize, Serialize};
 use tsify_next::Tsify;
 use wacore_libsignal::{
@@ -26,7 +26,7 @@ pub struct KeyPair {
 
 #[wasm_bindgen(js_name = generateKeyPair)]
 pub fn generate_key_pair() -> KeyPair {
-    let pair = CoreKeyPair::generate(&mut OsRng.unwrap_err());
+    let pair = CoreKeyPair::generate(&mut rand::make_rng::<StdRng>());
 
     KeyPair {
         pub_key: pair.public_key.serialize().to_vec(),
@@ -103,7 +103,7 @@ pub fn calculate_signature(
 
     let priv_key = parse_private_key(private_key_bytes)?;
     let signature = priv_key
-        .calculate_signature(message, &mut OsRng.unwrap_err())
+        .calculate_signature(message, &mut rand::make_rng::<StdRng>())
         .map_err(map_err)?;
 
     let result = Uint8Array::new_with_length(signature.len() as u32);

--- a/src/group_cipher.rs
+++ b/src/group_cipher.rs
@@ -1,5 +1,5 @@
 use js_sys::Uint8Array;
-use rand::{TryRngCore, rngs::OsRng};
+use rand::rngs::StdRng;
 use wasm_bindgen::prelude::*;
 
 use crate::group_types::SenderKeyDistributionMessage;
@@ -36,7 +36,7 @@ impl GroupCipher {
             &mut self.storage_adapter,
             &self.sender_key_name.0,
             plaintext,
-            &mut OsRng.unwrap_err(),
+            &mut rand::make_rng::<StdRng>(),
         )
         .await
         .map_err(map_err)?;
@@ -93,7 +93,7 @@ impl GroupSessionBuilder {
         let core_skdm = create_sender_key_distribution_message(
             &sender_key_name.0,
             &mut self.storage_adapter,
-            &mut OsRng.unwrap_err(),
+            &mut rand::make_rng::<StdRng>(),
         )
         .await
         .map_err(map_err)?;

--- a/src/key_helper.rs
+++ b/src/key_helper.rs
@@ -1,5 +1,5 @@
 use js_sys::{TypeError, Uint8Array};
-use rand::{TryRngCore as _, rngs::OsRng};
+use rand::{Rng, rngs::StdRng};
 use serde::Serialize;
 use tsify_next::Tsify;
 use wacore_libsignal::core::curve::{KeyPair as CoreKeyPair, PrivateKey as CorePrivateKey};
@@ -32,8 +32,8 @@ fn map_err(err: impl std::fmt::Display) -> JsValue {
     TypeError::new(&err.to_string()).into()
 }
 
-fn rng() -> impl rand::CryptoRng + rand::TryRngCore {
-    OsRng.unwrap_err()
+fn rng() -> impl rand::CryptoRng {
+    rand::make_rng::<StdRng>()
 }
 
 fn core_key_pair_to_key_pair(pair: CoreKeyPair) -> KeyPair {
@@ -51,7 +51,7 @@ pub fn generate_identity_key_pair() -> KeyPair {
 #[wasm_bindgen(js_name = generateRegistrationId)]
 pub fn generate_registration_id() -> u32 {
     let mut bytes = [0u8; 2];
-    rng().try_fill_bytes(&mut bytes).unwrap();
+    rng().fill_bytes(&mut bytes);
     (u16::from_le_bytes(bytes) & 0x3FFF) as u32
 }
 
@@ -67,11 +67,12 @@ pub fn generate_signed_pre_key(
     let identity_private_key =
         CorePrivateKey::deserialize(&identity_key_pair.priv_key).map_err(map_err)?;
 
-    let pre_key_pair = CoreKeyPair::generate(&mut rng());
+    let mut rng = rng();
+    let pre_key_pair = CoreKeyPair::generate(&mut rng);
     let pre_key_public_bytes = pre_key_pair.public_key.serialize();
 
     let signature = identity_private_key
-        .calculate_signature(&pre_key_public_bytes, &mut rng())
+        .calculate_signature(&pre_key_public_bytes, &mut rng)
         .map_err(map_err)?;
 
     Ok(SignedPreKey {

--- a/src/noise_session.rs
+++ b/src/noise_session.rs
@@ -1,5 +1,5 @@
 use js_sys::Uint8Array;
-use wacore_binary::consts::NOISE_START_PATTERN as NOISE_MODE;
+use wacore_binary::consts::NOISE_PATTERN_XX as NOISE_MODE;
 use wacore_binary::marshal::marshal_ref;
 use wacore_noise::framing::{FrameDecoder, encode_frame_into};
 use wacore_noise::{NoiseCipher, NoiseHandshake, build_handshake_header};
@@ -87,9 +87,11 @@ impl NoiseSession {
                 .ok_or_else(|| JsValue::from_str("Decryption cipher not initialized"))?;
             let counter = self.read_counter;
             self.read_counter += 1;
+            let mut buf = ciphertext.to_vec();
             cipher
-                .decrypt_with_counter(counter, ciphertext)
-                .map_err(|e| JsValue::from_str(&format!("Decryption failed: {}", e)))
+                .decrypt_in_place_with_counter(counter, &mut buf)
+                .map_err(|e| JsValue::from_str(&format!("Decryption failed: {}", e)))?;
+            Ok(buf)
         } else {
             self.handshake
                 .as_mut()

--- a/src/session_builder.rs
+++ b/src/session_builder.rs
@@ -1,4 +1,4 @@
-use rand::{TryRngCore, rngs::OsRng};
+use rand::rngs::StdRng;
 use serde::Deserialize;
 use tsify_next::Tsify;
 use wasm_bindgen::{JsValue, prelude::*};
@@ -113,7 +113,7 @@ impl SessionBuilder {
             &mut session_store,
             &mut identity_store,
             &bundle,
-            &mut OsRng.unwrap_err(),
+            &mut rand::make_rng::<StdRng>(),
             UsePQRatchet::No,
         )
         .await

--- a/src/session_cipher.rs
+++ b/src/session_cipher.rs
@@ -1,5 +1,5 @@
 use js_sys::{Object, Reflect, Uint8Array};
-use rand::{TryRngCore, rngs::OsRng};
+use rand::rngs::StdRng;
 use std::cell::RefCell;
 use wasm_bindgen::prelude::*;
 
@@ -92,7 +92,7 @@ impl SessionCipher {
             &mut identity_store,
             &mut prekey_store,
             &signed_prekey_store,
-            &mut OsRng.unwrap_err(),
+            &mut rand::make_rng::<StdRng>(),
             UsePQRatchet::No,
         )
         .await
@@ -125,7 +125,7 @@ impl SessionCipher {
             &self.remote_address.0,
             &mut session_store,
             &mut identity_store,
-            &mut OsRng.unwrap_err(),
+            &mut rand::make_rng::<StdRng>(),
         )
         .await
         .map_err(|e| {

--- a/src/session_cipher.rs
+++ b/src/session_cipher.rs
@@ -11,9 +11,7 @@ use wacore_libsignal::protocol::{self as libsignal, SessionStore, UsePQRatchet};
 
 #[inline]
 fn bytes_to_uint8array(bytes: &[u8]) -> Uint8Array {
-    let result = Uint8Array::new_with_length(bytes.len() as u32);
-    result.copy_from(bytes);
-    result
+    Uint8Array::from(bytes)
 }
 
 #[wasm_bindgen]

--- a/src/storage_adapter.rs
+++ b/src/storage_adapter.rs
@@ -786,18 +786,22 @@ impl SessionStore for JsStorageAdapter {
         }
     }
 
+    async fn has_session(&self, address: &libsignal::ProtocolAddress) -> SignalResult<bool> {
+        Ok(SessionStore::load_session(self, address).await?.is_some())
+    }
+
     async fn store_session(
         &mut self,
         address: &libsignal::ProtocolAddress,
-        record: &CoreSessionRecord,
+        record: CoreSessionRecord,
     ) -> SignalResult<()> {
         let address_str = self.get_address_string(address);
 
+        let bytes = record.serialize()?;
+
         self.cached_sessions
             .borrow_mut()
-            .insert(address_str.clone(), record.clone());
-
-        let bytes = record.serialize()?;
+            .insert(address_str.clone(), record);
 
         let result = if self.has_store_session_raw() {
             let uint8 = Uint8Array::from(bytes.as_slice());
@@ -1008,7 +1012,7 @@ impl SignedPreKeyStore for JsStorageAdapter {
 #[async_trait(?Send)]
 impl SenderKeyStore for JsStorageAdapter {
     async fn load_sender_key(
-        &mut self,
+        &self,
         sender_key_name: &CoreSenderKeyName,
     ) -> SignalResult<Option<CoreSenderKeyRecord>> {
         let key_id = self.get_sender_key_id(sender_key_name);
@@ -1059,15 +1063,15 @@ impl SenderKeyStore for JsStorageAdapter {
     async fn store_sender_key(
         &mut self,
         sender_key_name: &CoreSenderKeyName,
-        record: &CoreSenderKeyRecord,
+        record: CoreSenderKeyRecord,
     ) -> SignalResult<()> {
         let key_id = self.get_sender_key_id(sender_key_name);
 
+        let bytes = record.serialize()?;
+
         self.cached_sender_keys
             .borrow_mut()
-            .insert(key_id.clone(), record.clone());
-
-        let bytes = record.serialize()?;
+            .insert(key_id.clone(), record);
         let uint8 = Uint8Array::from(bytes.as_slice());
 
         let result = self


### PR DESCRIPTION
## Summary

Bumps the `wacore-*` / `waproto` deps to the 0.5 series and adapts the bridge to the resulting API changes.

## Notable changes

- **`hashify` cross-compile fix**: forces `force-32bit` so the PHF token lookup works on `wasm32` (otherwise some tokens silently return `None` due to a `u64 as usize` truncation in the generated code).
- **`SessionStore` redesign**: new `has_session` method, `record` taken by value (saves one clone per store).
- **`wacore-binary` types**: `Cow<str>` → `NodeStr`, `Vec<(K,V)>` → `AttrsRef`, `Box<Vec<NodeRef>>` → `Box<[NodeRef]>`.
- **bench fix**: each `summary()` in `benches/signal.ts` now gets its own session pair. The shared pair was advancing past `MAX_FORWARD_JUMPS = 25_000` once encrypt got fast enough for mitata's batch mode.

## Test plan

- [x] `bun test` — 163 pass / 0 fail
- [x] `bun run build` — clean
- [x] `node --expose-gc benches/signal.ts` — 5/5 runs consistent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved benchmark isolation and structure for more reliable performance testing.
  * Optimized cryptographic operations and randomness handling.
  * Enhanced node conversion logic for improved performance.

* **Chores**
  * Updated core dependencies to newer versions for enhanced compatibility and stability.
  * Refined storage adapter interfaces for better internal consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->