### PR TITLE
Load wasm files at runtime instead of inlining as base64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 dist
 node_modules
 pkg
-assets/wasm
 *.tgz
 *.xml
 docs

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "files": [
         "dist/index.js",
         "dist/index.d.ts",
+        "dist/whatsapp_rust_bridge_bg.simd.wasm",
+        "dist/whatsapp_rust_bridge_bg.nosimd.wasm",
         "pkg/whatsapp_rust_bridge.d.ts"
     ],
     "exports": {
@@ -24,7 +26,7 @@
         "bench": "bun run build && bun run benches/binary.ts && bun run benches/signal.ts && bun run benches/curve.ts && bun run benches/crypto.ts",
         "bench:node": "bun run build && node --expose-gc benches/binary.ts && node --expose-gc benches/signal.ts && node --expose-gc benches/curve.ts && node --expose-gc benches/crypto.ts",
         "build:wasm": "node scripts/build-wasm.mjs",
-        "build:ts": "bun build ts/index.ts --outfile dist/index.js",
+        "build:ts": "bun build ts/index.ts --outfile dist/index.js --target=node --external=node:fs",
         "prebuild": "rm -rf dist",
         "postbuild": "tsc -p tsconfig.json --outDir dist",
         "build": "bun run prebuild && bun run build:wasm && bun run build:ts && bun run postbuild",

--- a/scripts/build-wasm.mjs
+++ b/scripts/build-wasm.mjs
@@ -7,7 +7,11 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, "..");
 const pkgWasm = resolve(root, "pkg/whatsapp_rust_bridge_bg.wasm");
-const outDir = resolve(root, "assets/wasm");
+// Ship wasms straight into dist/ so the runtime loader (ts/index.ts) can
+// `readFileSync(new URL(name, import.meta.url))` against them at startup
+// without going through a base64 macro.
+const outDir = resolve(root, "dist");
+const variantFilename = (variant) => `whatsapp_rust_bridge_bg.${variant}.wasm`;
 
 const wasmOptFlags = [
   "-O4",
@@ -56,7 +60,7 @@ function build(variant) {
     { RUSTFLAGS: rustflags },
   );
 
-  const outFile = resolve(outDir, `${variant}.wasm`);
+  const outFile = resolve(outDir, variantFilename(variant));
   const optFlags = [
     ...wasmOptFlags,
     isSimd ? "--enable-simd" : "--disable-simd",
@@ -75,9 +79,9 @@ if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true });
 build("simd");
 build("nosimd");
 
-// Make pkg/whatsapp_rust_bridge_bg.wasm point to the SIMD variant for the
-// wasm-bindgen JS wrapper's default URL resolution (rebuild simd last so
-// pkg ends in a clean state for `wasm-pack publish`-style consumers).
-copyFileSync(resolve(outDir, "simd.wasm"), pkgWasm);
+// Mirror the SIMD variant back into pkg/ so `wasm-pack publish`-style
+// consumers and the wasm-bindgen JS wrapper's default URL resolution still
+// find a binary under the canonical name.
+copyFileSync(resolve(outDir, variantFilename("simd")), pkgWasm);
 
 console.log("\nDual wasm build complete.");

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -1,9 +1,5 @@
+import { readFileSync } from "node:fs";
 import { initSync } from "../pkg/whatsapp_rust_bridge.js";
-
-import {
-  nosimdWasmBase64,
-  simdWasmBase64,
-} from "./macro.js" with { type: "macro" };
 
 // Minimal WASM module that uses i8x16.splat + i8x16.popcnt. WebAssembly.validate
 // returns false on engines without SIMD (e.g. V8 on x86 without SSE4.1).
@@ -12,18 +8,10 @@ const SIMD_PROBE = new Uint8Array([
   8, 0, 65, 0, 253, 15, 253, 98, 11,
 ]);
 
-function base64ToUint8Array(base64: string): Uint8Array {
-  const binaryString = atob(base64);
-  const bytes = new Uint8Array(binaryString.length);
-  for (let i = 0; i < binaryString.length; i++) {
-    bytes[i] = binaryString.charCodeAt(i);
-  }
-  return bytes;
-}
-
-function tryInit(b64: string): boolean {
+function tryInit(filename: string): boolean {
   try {
-    initSync({ module: base64ToUint8Array(b64) });
+    const url = new URL(filename, import.meta.url);
+    initSync({ module: readFileSync(url) });
     return true;
   } catch {
     return false;
@@ -37,10 +25,12 @@ const forceNoSimd =
 const simdSupported = !forceNoSimd && WebAssembly.validate(SIMD_PROBE);
 
 let simdUsed = false;
-if (simdSupported && tryInit(simdWasmBase64())) {
+if (simdSupported && tryInit("whatsapp_rust_bridge_bg.simd.wasm")) {
   simdUsed = true;
-} else {
-  initSync({ module: base64ToUint8Array(nosimdWasmBase64()) });
+} else if (!tryInit("whatsapp_rust_bridge_bg.nosimd.wasm")) {
+  throw new Error(
+    "whatsapp-rust-bridge: failed to load WASM module (neither SIMD nor non-SIMD variant could be initialized)",
+  );
 }
 
 export const __wasmSimdActive: boolean = simdUsed;

--- a/ts/macro.ts
+++ b/ts/macro.ts
@@ -1,9 +1,0 @@
-import { readFileSync } from "fs";
-
-export const simdWasmBase64 = () => {
-  return readFileSync("./assets/wasm/simd.wasm").toBase64();
-};
-
-export const nosimdWasmBase64 = () => {
-  return readFileSync("./assets/wasm/nosimd.wasm").toBase64();
-};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "es2022",
     "module": "esnext",
     "lib": ["es2022", "dom"],
-    "types": ["node", "bun"],
+    "types": ["node"],
     "strict": true,
     "moduleResolution": "bundler",
     "esModuleInterop": true,
@@ -14,6 +14,5 @@
     "declaration": true,
     "emitDeclarationOnly": true
   },
-  "include": ["ts/**/*.ts"],
-  "exclude": ["ts/macro.ts"]
+  "include": ["ts/**/*.ts"]
 }


### PR DESCRIPTION
## Summary

Drops the `bun build` macro that embedded both wasm variants as base64 string constants in `dist/index.js`. Wasms are now emitted straight into `dist/` and loaded at startup via `readFileSync(new URL(name, import.meta.url))`.

## Why

- Base64-as-JS-constant kept ~1.4 MB of strings permanently resident in the JS heap (constants don't get GC'd). After `WebAssembly.Module` compiles raw bytes, the Buffer is collectable.
- 33% size overhead from base64 encoding goes away.

## Numbers

|  | before | after |
|---|---:|---:|
| `dist/index.js` | 2.0 MB | 71 KB |
| tarball compressed | 837 KB | 668 KB |
| tarball unpacked | 2.04 MB | 1.6 MB |

## Test plan

- [x] `bun test` — 163 pass / 0 fail
- [x] `cargo fmt --check`, `cargo clippy -D warnings` — clean
- [x] Tarball install + import in a fresh dir works (SIMD path picked correctly)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized WebAssembly module loading and initialization process.
  * Restructured build output and artifact handling.

* **Chores**
  * Updated build configuration and project settings.
  * Modified build script to support variant WebAssembly artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->