### PR TITLE
feat(client-profile): expose phone_id, locale, passive overrides to JS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1419,7 +1419,7 @@ dependencies = [
 [[package]]
 name = "wacore"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?branch=main#f9a937613c4ed323793e3254c90bf8705f4b8565"
+source = "git+https://github.com/oxidezap/whatsapp-rust?branch=main#20f1ce86acce3847dff999969d5fbc7169919bab"
 dependencies = [
  "aes",
  "anyhow",
@@ -1451,7 +1451,6 @@ dependencies = [
  "subtle",
  "thiserror",
  "typed-builder",
- "uuid",
  "wacore-appstate",
  "wacore-binary",
  "wacore-derive",
@@ -1463,7 +1462,7 @@ dependencies = [
 [[package]]
 name = "wacore-appstate"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?branch=main#f9a937613c4ed323793e3254c90bf8705f4b8565"
+source = "git+https://github.com/oxidezap/whatsapp-rust?branch=main#20f1ce86acce3847dff999969d5fbc7169919bab"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1484,7 +1483,7 @@ dependencies = [
 [[package]]
 name = "wacore-binary"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?branch=main#f9a937613c4ed323793e3254c90bf8705f4b8565"
+source = "git+https://github.com/oxidezap/whatsapp-rust?branch=main#20f1ce86acce3847dff999969d5fbc7169919bab"
 dependencies = [
  "bytes",
  "compact_str",
@@ -1500,7 +1499,7 @@ dependencies = [
 [[package]]
 name = "wacore-derive"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?branch=main#f9a937613c4ed323793e3254c90bf8705f4b8565"
+source = "git+https://github.com/oxidezap/whatsapp-rust?branch=main#20f1ce86acce3847dff999969d5fbc7169919bab"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1510,7 +1509,7 @@ dependencies = [
 [[package]]
 name = "wacore-libsignal"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?branch=main#f9a937613c4ed323793e3254c90bf8705f4b8565"
+source = "git+https://github.com/oxidezap/whatsapp-rust?branch=main#20f1ce86acce3847dff999969d5fbc7169919bab"
 dependencies = [
  "aes",
  "arrayref",
@@ -1542,7 +1541,7 @@ dependencies = [
 [[package]]
 name = "wacore-noise"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?branch=main#f9a937613c4ed323793e3254c90bf8705f4b8565"
+source = "git+https://github.com/oxidezap/whatsapp-rust?branch=main#20f1ce86acce3847dff999969d5fbc7169919bab"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1560,7 +1559,7 @@ dependencies = [
 [[package]]
 name = "waproto"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?branch=main#f9a937613c4ed323793e3254c90bf8705f4b8565"
+source = "git+https://github.com/oxidezap/whatsapp-rust?branch=main#20f1ce86acce3847dff999969d5fbc7169919bab"
 dependencies = [
  "prost",
  "serde",
@@ -1699,7 +1698,7 @@ dependencies = [
 [[package]]
 name = "whatsapp-rust"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?branch=main#f9a937613c4ed323793e3254c90bf8705f4b8565"
+source = "git+https://github.com/oxidezap/whatsapp-rust?branch=main#20f1ce86acce3847dff999969d5fbc7169919bab"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "whatsapp-rust-bridge",
-    "version": "0.6.0-alpha.27",
+    "version": "0.6.0-alpha.28",
     "description": "A high-performance utilities for WhatsApp, powered by Rust and WebAssembly.",
     "author": "João Lucas <jlucaso@hotmail.com>",
     "license": "MIT",

--- a/src/client_profile.rs
+++ b/src/client_profile.rs
@@ -9,6 +9,37 @@ use serde::{Deserialize, Serialize};
 use tsify_next::Tsify;
 use wacore::client_profile::ClientProfile;
 
+/// Optional Noise-payload overrides applied on top of every preset.
+/// Leaving any field `None` preserves wacore's default, which matches
+/// WA Web (notably `phoneId` stays unset on the wire).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+#[serde(default, rename_all = "camelCase")]
+pub struct ClientProfileOverrides {
+    pub phone_id: Option<String>,
+    pub locale_language: Option<String>,
+    pub locale_country: Option<String>,
+    pub passive_login: Option<bool>,
+}
+
+impl ClientProfileOverrides {
+    fn apply(self, mut profile: ClientProfile) -> ClientProfile {
+        if self.phone_id.is_some() {
+            profile.phone_id = self.phone_id;
+        }
+        if let Some(lang) = self.locale_language {
+            profile.locale_language = lang;
+        }
+        if let Some(country) = self.locale_country {
+            profile.locale_country = country;
+        }
+        if let Some(passive) = self.passive_login {
+            profile.passive_login = passive;
+        }
+        profile
+    }
+}
+
 /// Selects which `ClientProfile` preset to use for the noise-handshake
 /// `ClientPayload.UserAgent`. Independent of `DeviceProps`: `setDeviceProps`
 /// controls the "Linked Devices" display on the phone, this controls what
@@ -17,6 +48,9 @@ use wacore::client_profile::ClientProfile;
 /// Use `{ preset: 'android', osVersion: '13' }` to mirror the upstream
 /// Baileys `Browsers.android('13')` behavior (UserAgent.platform = ANDROID,
 /// `web_info` omitted).
+///
+/// Every variant flattens the [`ClientProfileOverrides`] fields, so the
+/// JS literal is flat (e.g. `{ preset: 'web', phoneId: 'fixed-id' }`).
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(
@@ -25,23 +59,61 @@ use wacore::client_profile::ClientProfile;
     rename_all_fields = "camelCase"
 )]
 pub enum ClientProfileInput {
-    Web,
-    Android { os_version: String },
-    SmbAndroid { os_version: String },
-    Ios { os_version: String },
-    Macos { os_version: String },
-    Windows { os_version: String },
+    Web {
+        #[serde(flatten)]
+        overrides: ClientProfileOverrides,
+    },
+    Android {
+        os_version: String,
+        #[serde(flatten)]
+        overrides: ClientProfileOverrides,
+    },
+    SmbAndroid {
+        os_version: String,
+        #[serde(flatten)]
+        overrides: ClientProfileOverrides,
+    },
+    Ios {
+        os_version: String,
+        #[serde(flatten)]
+        overrides: ClientProfileOverrides,
+    },
+    Macos {
+        os_version: String,
+        #[serde(flatten)]
+        overrides: ClientProfileOverrides,
+    },
+    Windows {
+        os_version: String,
+        #[serde(flatten)]
+        overrides: ClientProfileOverrides,
+    },
 }
 
 impl From<ClientProfileInput> for ClientProfile {
     fn from(input: ClientProfileInput) -> Self {
         match input {
-            ClientProfileInput::Web => ClientProfile::web(),
-            ClientProfileInput::Android { os_version } => ClientProfile::android(os_version),
-            ClientProfileInput::SmbAndroid { os_version } => ClientProfile::smb_android(os_version),
-            ClientProfileInput::Ios { os_version } => ClientProfile::ios(os_version),
-            ClientProfileInput::Macos { os_version } => ClientProfile::macos(os_version),
-            ClientProfileInput::Windows { os_version } => ClientProfile::windows(os_version),
+            ClientProfileInput::Web { overrides } => overrides.apply(ClientProfile::web()),
+            ClientProfileInput::Android {
+                os_version,
+                overrides,
+            } => overrides.apply(ClientProfile::android(os_version)),
+            ClientProfileInput::SmbAndroid {
+                os_version,
+                overrides,
+            } => overrides.apply(ClientProfile::smb_android(os_version)),
+            ClientProfileInput::Ios {
+                os_version,
+                overrides,
+            } => overrides.apply(ClientProfile::ios(os_version)),
+            ClientProfileInput::Macos {
+                os_version,
+                overrides,
+            } => overrides.apply(ClientProfile::macos(os_version)),
+            ClientProfileInput::Windows {
+                os_version,
+                overrides,
+            } => overrides.apply(ClientProfile::windows(os_version)),
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added customizable client profile settings, including phone ID, locale language and country, and passive login configuration.

* **Chores**
  * Updated package version to 0.6.0-alpha.28.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhiskeySockets/whatsapp-rust-bridge/pull/18?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->